### PR TITLE
add fw versions for 2018 Nissan Leaf JP

### DIFF
--- a/selfdrive/car/nissan/values.py
+++ b/selfdrive/car/nissan/values.py
@@ -66,15 +66,18 @@ FW_VERSIONS = {
     #],
     (Ecu.eps, 0x742, None): [
       b'5SH2A\x99A\x05\x02N123F\x15\x81\x00\x00\x00\x00\x00\x00\x00\x80',
+      b'5SK3A\x99A\x05\x02N123F\x25u\x00\x00\x00\x00\x00\x00\x00\x80',
     ],
     #(Ecu.fwdCamera, 0x787, None): [
     #  b'',
     #],
     (Ecu.engine, 0x797, None): [
       b'5SH4A\x03AB\x075SH4APSMT04\x00\x00\x00\x80',
+      b'5SK9B\x03AB\x075SK9BPSMI03\x00\x00\x00\x80',
     ],
     (Ecu.transmission, 0x79d, None): [
       b'5SA2B\x04AB\x071\x03\x80\x12P\x02\x03D\x00\x02\x06\x00\x00\x00\x80',
+      b'5SA3B\x04AB\x071\x03\x80\x22P\x02\x03D\x00\x01\x06\x00\x00\x00\x80',
     ],
   },
 }


### PR DESCRIPTION
I added the FW versions of my Nissan Leaf 2018 (japanese) from the useradmin car params.

Just to confirm: We replace \0 -> \x , \a -> \x07 etc. , right?

BTW, are you sure about 0x797 being the engine? From what I read it seems to be the VCM (from which we should also query the VIN at some point).